### PR TITLE
Create GitHub Actions workflow to auto update metrics file when publications file is changed

### DIFF
--- a/.github/workflows/update-publications-metrics.yaml
+++ b/.github/workflows/update-publications-metrics.yaml
@@ -32,45 +32,44 @@ jobs:
 
 
     # Run the job only with "docs_changed" equals "True"
-    conditional_job:
-      runs-on: 'ubuntu-20.04'
-      needs: [ conditional_job_check_files ]
-      if: needs.conditional_job_check_files.outputs.docs_changed == 'True'
-      steps:
-      - shell: pwsh
-        run: echo publish docs
+  conditional_job:
+    runs-on: 'ubuntu-20.04'
+    needs: [ conditional_job_check_files ]
+    if: needs.conditional_job_check_files.outputs.docs_changed == 'True'
+    steps:
+    - shell: pwsh
+      run: echo publish docs
   
   
-      - name: Update publications metrics
-        shell: python
-        run: |
-          from ruamel.yaml import YAML
+    - name: Update publications metrics
+      shell: python
+      run: |
+        from ruamel.yaml import YAML
 
-          yaml = YAML()
-          publications_file = 'data/publications.yml'
-          metrics_file = 'data/metrics.yml'
+        yaml = YAML()
+        publications_file = 'data/publications.yml'
+        metrics_file = 'data/metrics.yml'
           
-          with open('publications_file', 'r') as f:
-            publications_dict = yaml.load(f)
-            number = len(publications_dict['items'])
+        with open('publications_file', 'r') as f:
+          publications_dict = yaml.load(f)
+          number = len(publications_dict['items'])
 
-          with open('metrics_file', 'w') as f:
-            metrics_dict = yaml.load(f)
-            metrics_dict['counter_items'][1][number] = number
+        with open('metrics_file', 'w') as f:
+          metrics_dict = yaml.load(f)
+          metrics_dict['counter_items'][1][number] = number
             
 
-      - name: Create pull request
-        id: cpr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          commit-message: 'Update publication metrics'
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          base: main
-          title: 'Update publications metrics'
-          body: |
-            Update publicaions metrics on landing page based on changes to `publications.yml`.
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: publication-metrics
+    - name: Create pull request
+      id: cpr
+      uses: peter-evans/create-pull-request@v4
+      with:
+        commit-message: 'Update publication metrics'
+        committer: GitHub <noreply@github.com>
+        signoff: false
+        base: main
+        title: 'Update publications metrics'
+        body: |
+          Update publicaions metrics on landing page based on changes to `publications.yml`.
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: publication-metrics
  

--- a/.github/workflows/update-publications-metrics.yaml
+++ b/.github/workflows/update-publications-metrics.yaml
@@ -24,7 +24,7 @@ jobs:
         $diff = git diff --name-only HEAD^ HEAD
 
         # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-        $SourceDiff = $diff | Where-Object { $_ -match 'data/metrics.yml' }
+        $SourceDiff = $diff | Where-Object { $_ -match 'data/publications.yml' }
         $HasDiff = $SourceDiff.Length -gt 0
 
         # Set the output named "docs_changed"

--- a/.github/workflows/update-publications-metrics.yaml
+++ b/.github/workflows/update-publications-metrics.yaml
@@ -1,0 +1,76 @@
+name: Update Publications Metrics
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      
+jobs:
+  conditional_job_check_files:
+    runs-on: 'ubuntu-20.04'
+    outputs:
+      docs_changed: ${{ steps.check_file_changed.outputs.docs_changed }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - shell: pwsh
+      id: check_file_changed
+      run: |
+        # Diff HEAD with the previous commit
+        $diff = git diff --name-only HEAD^ HEAD
+
+        # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
+        $SourceDiff = $diff | Where-Object { $_ -match 'data/metrics.yml' }
+        $HasDiff = $SourceDiff.Length -gt 0
+
+        # Set the output named "docs_changed"
+        Write-Host "::set-output name=docs_changed::$HasDiff"
+
+
+    # Run the job only with "docs_changed" equals "True"
+    conditional_job:
+      runs-on: 'ubuntu-20.04'
+      needs: [ conditional_job_check_files ]
+      if: needs.conditional_job_check_files.outputs.docs_changed == 'True'
+      steps:
+      - shell: pwsh
+        run: echo publish docs
+  
+  
+      - name: Update publications metrics
+        shell: python
+        run: |
+          from ruamel.yaml import YAML
+
+          yaml = YAML()
+          publications_file = 'data/publications.yml'
+          metrics_file = 'data/metrics.yml'
+          
+          with open('publications_file', 'r') as f:
+            publications_dict = yaml.load(f)
+            number = len(publications_dict['items'])
+
+          with open('metrics_file', 'w') as f:
+            metrics_dict = yaml.load(f)
+            metrics_dict['counter_items'][1][number] = number
+            
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: 'Update publication metrics'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          base: main
+          title: 'Update publications metrics'
+          body: |
+            Update publicaions metrics on landing page based on changes to `publications.yml`.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: publication-metrics
+ 


### PR DESCRIPTION
This GH Action checks the latest commits to see if the files changed match `data/publications.yml` and if so, grabs the length of the publications list and updates the number in the publications metrics with that number.

Also this PR template seems left over from some borrowed code:
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
